### PR TITLE
audiooutput: fallback to primary device if secondary is not set

### DIFF
--- a/lib/engine/audiooutput/audiooutput-core.cpp
+++ b/lib/engine/audiooutput/audiooutput-core.cpp
@@ -189,7 +189,7 @@ void AudioOutputCore::set_device(AudioOutputPS ps, const AudioOutputDevice & dev
 
       break;
     case secondary:
-        if (device == current_device[primary])
+        if (device == current_device[primary] || device.name == "")
         {
           current_manager[secondary] = NULL;
           current_device[secondary].type = "";

--- a/lib/engine/audiooutput/audiooutput-gmconf-bridge.cpp
+++ b/lib/engine/audiooutput/audiooutput-gmconf-bridge.cpp
@@ -134,9 +134,7 @@ void AudioOutputCoreConfBridge::on_property_changed (std::string key, GmConfEntr
          (device.source == "") ||
          (device.name   == "") ) {
       PTRACE(1, "AudioOutputCore\tTried to set malformed device");
-      device.type   = AUDIO_OUTPUT_FALLBACK_DEVICE_TYPE;
-      device.source = AUDIO_OUTPUT_FALLBACK_DEVICE_SOURCE;
-      device.name   = AUDIO_OUTPUT_FALLBACK_DEVICE_NAME;
+      device.name   = "";
     }
     audiooutput_core.set_device (secondary, device);
   }


### PR DESCRIPTION
Ekiga already falls back to the primary audio output device
when the manager for the secondary device is NULL. But the
gmconf bridge will set the SILENT device if an empty setting for
the secondary device is encountered, which effectively mutes
ekiga's ring tone unless the user actively reconfigures the
secondary device. The primary device, if not set, defaults to
the first detected audio device on the system, which is a
more reasonable default than SILENT.

This patch changes the behavior for the secondary device such
that the primary device fallback is used for the secondary
device if no configuration is found.

Solves: https://bugs.launchpad.net/ubuntu/+source/ekiga/+bug/558304